### PR TITLE
Solves unnecessarily iterating list twice

### DIFF
--- a/src/Nano.DependencyInjector/NanoDependencyInjectorExtensions.cs
+++ b/src/Nano.DependencyInjector/NanoDependencyInjectorExtensions.cs
@@ -34,7 +34,7 @@ namespace Nano.DependencyInjector
             object instance;
             ConstructorInfo publicConstructor = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public,
                 null, new[] {typeof(string)}, null);
-            
+
             if (publicConstructor == null)
             {
                 instance = System.Runtime.Serialization.FormatterServices

--- a/tests/Nano.DependencyInjector.Tests/ListExtensionTests.cs
+++ b/tests/Nano.DependencyInjector.Tests/ListExtensionTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Xunit;
 
@@ -10,14 +11,32 @@ namespace Nano.DependencyInjector.Tests
         {
             var falseHeroes = new List<string>();
             var heroes = new List<string>() {"Conan", "Spawn", "Batman"};
-            heroes.If(IsBestHero)
+            heroes.If(IsThisTheBestHero)
                 .True(t => Assert.Equal("Conan", t))
                 .False(f => falseHeroes.Add(f));
 
             Assert.Equal(2, falseHeroes.Count);
         }
 
-        private bool IsBestHero(string hero)
+        [Fact]
+        public void There_Can_Be_Only_True_Action()
+        {
+            bool called = false;
+
+            void TrueAct(string t)
+            {
+                called = true;
+            }
+
+            var heroes = new List<string>() {"Conan", "Spawn", "Batman"};
+            heroes.If(IsThisTheBestHero)
+                .True(TrueAct)
+                .Run();
+
+            Assert.True(called);
+        }
+
+        private bool IsThisTheBestHero(string hero)
         {
             return hero == "Conan";
         }


### PR DESCRIPTION
```
var trueResult = list.Where(i => ifStatement(i));
var falseResult = list.Where(i => !ifStatement(i));
```

It might cause some performance issue. With this PR, it will be O(n).

Sorry for the inconvenience. I was so sleepy when I wrote old one.